### PR TITLE
Improve log filtering

### DIFF
--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -18,13 +18,6 @@ import (
 	"github.com/NFT-com/indexer/store"
 )
 
-const (
-	TopicTransfer       = "Transfer"
-	TopicTransferSingle = "TransferSingle"
-	TopicTransferBatch  = "TransferBatch"
-	TopicURI            = "URI"
-)
-
 type Contract struct {
 	log zerolog.Logger
 

--- a/contracts/topics.go
+++ b/contracts/topics.go
@@ -1,0 +1,29 @@
+package contracts
+
+import "github.com/ethereum/go-ethereum/common"
+
+const (
+	TopicTransfer       = "Transfer"
+	TopicTransferSingle = "TransferSingle"
+	TopicTransferBatch  = "TransferBatch"
+	TopicURI            = "URI"
+)
+
+func TopicHash(topic string) common.Hash {
+	switch topic {
+	case TopicTransfer:
+		return common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+
+	case TopicTransferSingle:
+		return common.HexToHash("0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62")
+
+	case TopicTransferBatch:
+		return common.HexToHash("0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb")
+
+	case TopicURI:
+		return common.HexToHash("0x6bb7ff708619ba0610cba295a58592e0451dee2622938c8755667688daf3529b")
+
+	default:
+		return common.Hash{}
+	}
+}

--- a/parse/ethereum/parser.go
+++ b/parse/ethereum/parser.go
@@ -35,8 +35,18 @@ func (p *Parser) Parse(ctx context.Context, block *parse.Block) ([]events.Event,
 	logger := p.log.With().Str("block_hash", block.String()).Logger()
 	outEvents := make([]events.Event, 0, 64)
 
-	// FIXME: Filter by address/topic as well, to fetch only relevant data and speed up the parsing process.
-	logs, err := p.client.FilterLogs(ctx, ethereum.FilterQuery{BlockHash: &hash})
+	query := ethereum.FilterQuery{
+		BlockHash: &hash,
+		Topics: [][]common.Hash{
+			{
+				contracts.TopicHash(contracts.TopicTransfer),
+				contracts.TopicHash(contracts.TopicTransferSingle),
+				contracts.TopicHash(contracts.TopicTransferBatch),
+				contracts.TopicHash(contracts.TopicURI),
+			},
+		},
+	}
+	logs, err := p.client.FilterLogs(ctx, query)
 	if err != nil {
 		// FIXME: Should we stop the subscriber in this case?
 		logger.Error().Err(err).Msg("could not filter ethereum client logs")


### PR DESCRIPTION
## Goal of this PR

This PR improves #1 by filtering logs specifically for the topics we are interested in. This should increase the performance of indexing and makes the code more explicit, since we directly see what we subscribe to instead of subscribing to everything and then doing another manual filtering step.

@ricardomgoncalves Please review this PR, and if/when it is satisfactory, feel free to merge it at your convenience :p 