### PR TITLE
fix addition panic on result nft nil

### DIFF
--- a/cmd/action-dispatcher/main.go
+++ b/cmd/action-dispatcher/main.go
@@ -62,7 +62,7 @@ func run() int {
 	pflag.IntVarP(&flagRedisDB, "redis-database", "d", 1, "redis database number")
 	pflag.StringVarP(&flagRedisURL, "redis-url", "u", "127.0.0.1:6379", "redis server url")
 	pflag.StringVarP(&flagAWSRegion, "aws-region", "r", "eu-west-1", "aws region for Lambda invocation")
-	pflag.StringVarP(&flagLambdaName, "lambda-name", "n", "parsing-worker", "name of the lambda function to invoke")
+	pflag.StringVarP(&flagLambdaName, "lambda-name", "n", "action-worker", "name of the lambda function to invoke")
 
 	pflag.UintVar(&flagOpenConnections, "db-connection-limit", 128, "maximum number of database connections, -1 for unlimited")
 	pflag.UintVar(&flagIdleConnections, "db-idle-connection-limit", 32, "maximum number of idle connections")

--- a/service/pipeline/action_consumer.go
+++ b/service/pipeline/action_consumer.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	storage "github.com/NFT-com/indexer/storage/jobs"
 	"github.com/adjust/rmq/v4"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog"
@@ -20,6 +19,7 @@ import (
 	"github.com/NFT-com/indexer/models/inputs"
 	"github.com/NFT-com/indexer/models/jobs"
 	"github.com/NFT-com/indexer/models/results"
+	storage "github.com/NFT-com/indexer/storage/jobs"
 )
 
 type ActionConsumer struct {
@@ -184,10 +184,6 @@ func (a *ActionConsumer) processAddition(payload []byte, action *jobs.Action) er
 	err = json.Unmarshal(output, &result)
 	if err != nil {
 		return fmt.Errorf("could not decode NFT: %w", err)
-	}
-
-	if result.NFT == nil {
-		return fmt.Errorf("could not get nft from result")
 	}
 
 	result.NFT.CollectionID = collection.ID


### PR DESCRIPTION
Issue running the indexer.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x81e3fd]

goroutine 7 [running]:
github.com/NFT-com/indexer/service/pipeline.(*ActionConsumer).processAddition(0xc0002bd110, {0xc0003e21c0, 0x1b1, 0x1c0}, 0x1)
	/app/service/pipeline/action_consumer.go:188 +0x25d
github.com/NFT-com/indexer/service/pipeline.(*ActionConsumer).process(0xc0002bd110, {0xc0003e21c0, 0x1b1, 0x1c0})
	/app/service/pipeline/action_consumer.go:101 +0x605
github.com/NFT-com/indexer/service/pipeline.(*ActionConsumer).Consume(0xc000042780, {0xae5fb8, 0xc0002a9d50})
	/app/service/pipeline/action_consumer.go:72 +0xcd
github.com/adjust/rmq/v4.(*redisQueue).consumerConsume(0xc00030e000, {0xadba40, 0xc0002bd110})
	/go/pkg/mod/github.com/adjust/rmq/v4@v4.0.4/queue.go:295 +0x96
created by github.com/adjust/rmq/v4.(*redisQueue).AddConsumer
	/go/pkg/mod/github.com/adjust/rmq/v4@v4.0.4/queue.go:271 +0xaf
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x81e3fd]
```