### PR TITLE
Add retry for Lambda rate exceeded error

### DIFF
--- a/models/results/retriable.go
+++ b/models/results/retriable.go
@@ -25,10 +25,12 @@ func Retriable(err error) bool {
 	case strings.Contains(msg, "Gateway Timeout"):
 		return true
 
-	// failure due to Lambda file descriptor limit
+	// failure due to Lambda file descriptor limit or rate limit
 	case strings.Contains(msg, "too many open files"):
 		return true
 	case strings.Contains(msg, "no such host"):
+		return true
+	case strings.Contains(msg, "Rate Exceeded."):
 		return true
 
 	// failure due to HTTP request issue

--- a/storage/jobs/failure_repository.go
+++ b/storage/jobs/failure_repository.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/NFT-com/indexer/models/jobs"
 	"github.com/lib/pq"
+
+	"github.com/NFT-com/indexer/models/jobs"
 )
 
 type FailureRepository struct {


### PR DESCRIPTION
We currently do not retry on some Lambda errors where we should:

```
{"level":"error","error":"could not invoke lambda: operation error Lambda: Invoke, exceeded maximum number of attempts, 3, https response error StatusCode: 429, RequestID: 2ba7f96a-0efc-48a7-ae77-96c70a0dc89f, TooManyRequestsException: Rate Exceeded.","time":"2022-06-27T20:28:30Z","message":"could not process message, discarding"}
```