### PR TITLE
Add SQL conflict resolution for failures

### DIFF
--- a/storage/jobs/failure_repository.go
+++ b/storage/jobs/failure_repository.go
@@ -45,7 +45,8 @@ func (b *FailureRepository) Parsing(parsing *jobs.Parsing, message string) error
 			pq.Array(parsing.ContractAddresses),
 			pq.Array(parsing.EventHashes),
 			message,
-		)
+		).
+		Suffix("ON CONFLICT (id) DO UPDATE SET failure_message = EXCLUDED.failure_message")
 
 	_, err := query.Exec()
 	if err != nil {
@@ -78,7 +79,8 @@ func (b *FailureRepository) Addition(addition *jobs.Addition, message string) er
 			addition.OwnerAddress,
 			addition.TokenCount,
 			message,
-		)
+		).
+		Suffix("ON CONFLICT (id) DO UPDATE SET failure_message = EXCLUDED.failure_message")
 
 	_, err := query.Exec()
 	if err != nil {


### PR DESCRIPTION
This PR adds conflict resolution for failures, in case some jobs are executed and fail twice. This avoids crashing the indexer, since insertions should pretty much be idempotent anyway. As a resolution of the conflict, it simply updates the failure message, because only the last failure message should really be relevant.