### PR TITLE
Support for wyvern v1

### DIFF
--- a/sql/06_insert_marketplaces_data.sql
+++ b/sql/06_insert_marketplaces_data.sql
@@ -7,6 +7,8 @@ VALUES ('df87df1d-f0a1-4e53-b2c3-77e794a76cf2', 'OpenSea',
 INSERT INTO networks_marketplaces
     (network_id, marketplace_id, contract_address, start_height)
 VALUES ('94c754fe-e06c-4d2b-bb76-2faa240b5bb8', 'df87df1d-f0a1-4e53-b2c3-77e794a76cf2',
+        '0x7be8076f4ea4a4ad08075c2508e481d6c946d12b', 5774644),
+       ('94c754fe-e06c-4d2b-bb76-2faa240b5bb8', 'df87df1d-f0a1-4e53-b2c3-77e794a76cf2',
         '0x7f268357A8c2552623316e2562D90e642bB538E5', 14120913);
 
 INSERT INTO marketplaces_standards (marketplace_id, standard_id)


### PR DESCRIPTION
After some research found out that wyvern v1 contract event for orders matched is the exactly same as v2, so in order to process v1 events we jut need to add a new contract address.