### PR TITLE
Minor tweaks to the database schema

### DIFF
--- a/sql/01_tables_graph_database.sql
+++ b/sql/01_tables_graph_database.sql
@@ -1,7 +1,7 @@
 CREATE TABLE networks
 (
     id          UUID PRIMARY KEY,
-    chain_id    NUMERIC     NOT NULL UNIQUE,
+    chain_id    BIGINT      NOT NULL UNIQUE,
     name        TEXT        NOT NULL,
     description TEXT        NOT NULL,
     symbol      VARCHAR(16) NOT NULL
@@ -20,7 +20,7 @@ CREATE TABLE collections
     id               UUID PRIMARY KEY,
     network_id       UUID         NOT NULL REFERENCES networks ON DELETE CASCADE,
     contract_address VARCHAR(128) NOT NULL,
-    start_height     NUMERIC      NOT NULL,
+    start_height     BIGINT       NOT NULL,
     name             TEXT         NOT NULL,
     description      TEXT         NOT NULL,
     symbol           VARCHAR(16)  NOT NULL,
@@ -86,7 +86,7 @@ CREATE TABLE networks_marketplaces
     network_id       UUID         NOT NULL REFERENCES networks ON DELETE CASCADE,
     marketplace_id   UUID         NOT NULL REFERENCES marketplaces ON DELETE CASCADE,
     contract_address VARCHAR(128) NOT NULL,
-    start_height     NUMERIC      NOT NULL,
+    start_height     BIGINT       NOT NULL,
     PRIMARY KEY (network_id, marketplace_id, contract_address)
 );
 

--- a/sql/02_tables_events_database.sql
+++ b/sql/02_tables_events_database.sql
@@ -1,11 +1,11 @@
 CREATE TABLE transfers
 (
     id                 UUID PRIMARY KEY,
-    chain_id           INTEGER      NOT NULL,
+    chain_id           BIGINT       NOT NULL,
     token_standard     VARCHAR(128) NOT NULL,
     collection_address VARCHAR(128) NOT NULL,
     token_id           VARCHAR(128) NOT NULL,
-    block_number       NUMERIC      NOT NULL,
+    block_number       BIGINT      NOT NULL,
     transaction_hash   VARCHAR(128) NOT NULL,
     event_index        INTEGER      NOT NULL,
     sender_address     VARCHAR(128) NOT NULL,
@@ -23,11 +23,11 @@ CREATE INDEX transfers_token_id_idx ON transfers (token_id);
 CREATE TABLE sales
 (
     id                  UUID PRIMARY KEY,
-    chain_id            INTEGER      NOT NULL,
+    chain_id            BIGINT       NOT NULL,
     marketplace_address VARCHAR(128) NOT NULL,
     collection_address  VARCHAR(128) NOT NULL,
     token_id            VARCHAR(128) NOT NULL,
-    block_number        NUMERIC      NOT NULL,
+    block_number        BIGINT       NOT NULL,
     transaction_hash    VARCHAR(128) NOT NULL,
     event_index         INTEGER      NOT NULL,
     seller_address      VARCHAR(128) NOT NULL,


### PR DESCRIPTION
This PR makes slight tweaks to the database schema..

1. Change `chain_id` column to an `INTEGER` instead of a `NUMERIC`.

Numeric is arbitrary precision which we don't need in this case, as chain IDs are small integers. Would decrease table size and improve performance, see here - https://dba.stackexchange.com/a/110882. I would argue that we can also switch to `BIGINT` for the `block_number` column, which is also a numeric, though we use that column in queries a lot less.

2. Change the `sales_collection_address_idx` index to also include the `token_id` besides the lowercased collection address.

We never do queries based on `token_id` alone. We typically do
```sql
SELECT *
FROM sales
WHERE LOWER(collection_address) = LOWER('0x123456789') AND token_id = 'X'
```

With the current setup we have two indexes - one on lowercased `collection_address` and one on `token_id`. On query execution, database engine will do one index scan on `collection_address`, one on `token_id`, and do a BitmapAnd to see which rows match on both conditions. 

If we instead have an index on `LOWER(collection_address), token_id`, then a single index will be used in a query. 

So the difference is doing two index scans + additional operations vs a single index scan. On a really trivial test I did locally on a table with 7.5M rows, the `SELECT` in the first case takes 0.771 ms of planning and 101.433 ms of execution; the second one takes 0.391 ms for planning and 0.138 ms for execution.

On the other hand, all queries doing
```sql
SELECT *
FROM sales
WHERE LOWER(collection_address) = LOWER(`0x123456789')
```
will still benefit just as much from the index (since collection address is the leftmost column), so we don't lose anything in performance there.


