### PR TITLE
Extract token count in sales completion

### DIFF
--- a/models/events/sale.go
+++ b/models/events/sale.go
@@ -12,7 +12,7 @@ type Sale struct {
 	MarketplaceAddress string    `json:"marketplace_address"`
 	CollectionAddress  string    `json:"collection_address"`
 	TokenID            string    `json:"token_id"`
-	TokenCount         uint      `json:"token_count"`
+	TokenCount         string    `json:"token_count"`
 	BlockNumber        uint64    `json:"block_number"`
 	TransactionHash    string    `json:"transaction_hash"`
 	EventIndex         uint      `json:"event_index"`

--- a/service/parsers/seaport_sale.go
+++ b/service/parsers/seaport_sale.go
@@ -260,7 +260,7 @@ func SeaportSale(log types.Log) (*events.Sale, error) {
 		MarketplaceAddress: log.Address.Hex(),
 		CollectionAddress:  nft.Address.Hex(),
 		TokenID:            nft.Identifier.String(),
-		TokenCount:         uint(nft.Amount.Uint64()),
+		TokenCount:         nft.Amount.String(),
 		BlockNumber:        log.BlockNumber,
 		TransactionHash:    log.TxHash.Hex(),
 		EventIndex:         log.Index,

--- a/service/parsers/wyvern_sale.go
+++ b/service/parsers/wyvern_sale.go
@@ -61,7 +61,7 @@ func WyvernSale(log types.Log) (*events.Sale, error) {
 		MarketplaceAddress: log.Address.Hex(),
 		CollectionAddress:  "", // Done in completion pipeline
 		TokenID:            "", // Done in completion pipeline
-		TokenCount:         0,  // Done in completion pipeline
+		TokenCount:         "", // Done in completion pipeline
 		BlockNumber:        log.BlockNumber,
 		TransactionHash:    log.TxHash.Hex(),
 		EventIndex:         log.Index,

--- a/service/workers/completion_handler.go
+++ b/service/workers/completion_handler.go
@@ -194,6 +194,7 @@ func (p *CompletionHandler) Handle(ctx context.Context, completion *jobs.Complet
 		nftTransfer := nftTransfers[0]
 		sale.CollectionAddress = nftTransfer.CollectionAddress
 		sale.TokenID = nftTransfer.TokenID
+		sale.TokenCount = nftTransfer.TokenCount
 	}
 
 	// Put everything together for the result.


### PR DESCRIPTION
This PR makes sure that we properly extract the token count from the NFT transfer for sales, so the information is included in the event.