### PR TITLE
Improve performance of owner sanitizing

### DIFF
--- a/storage/graph/owner_repository.go
+++ b/storage/graph/owner_repository.go
@@ -76,8 +76,6 @@ func (o *OwnerRepository) Upsert(transfers ...*events.Transfer) error {
 
 func (o *OwnerRepository) Sanitize() error {
 
-	// SELECT owner, nft_id, SUM(o.number) AS number FROM owners GROUP BY owner, nft_id HAVING SUM(number) = 0;
-
 	result, err := o.build.
 		Select("owner", "nft_id").
 		From("owners").


### PR DESCRIPTION
This PR changes the way we query the owner database for redundant ownership information.

At any point, if there are owners whose ownership count for an NFT is zero, we purge them from the database. With this new approach, we do not need to join the table anymore. It's a bit less precise, but should work fine as all DB actions in that regard are sequential in the parsing dispatcher.