### PR TITLE
Handle application-level/ipfs-based deletions

### DIFF
--- a/models/results/error.go
+++ b/models/results/error.go
@@ -1,5 +1,11 @@
 package results
 
+import (
+	"errors"
+)
+
+var ErrTokenNotFound = errors.New("token not found")
+
 type Error struct {
 	Message string `json:"errorMessage"`
 	Type    string `json:"errorType"`

--- a/network/web2/metadata_fetcher.go
+++ b/network/web2/metadata_fetcher.go
@@ -33,22 +33,18 @@ func NewMetadataFetcher(options ...MetadataOption) *MetadataFetcher {
 	return &m
 }
 
-func (m *MetadataFetcher) Payload(_ context.Context, uri string) ([]byte, error) {
+func (m *MetadataFetcher) Payload(_ context.Context, uri string) ([]byte, int, error) {
 
 	res, err := m.client.Get(uri)
 	if err != nil {
-		return nil, fmt.Errorf("could not execute request: %w", err)
+		return nil, 0, fmt.Errorf("could not execute request: %w", err)
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("bad response code (%d)", res.StatusCode)
-	}
-
 	payload, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("could not read response body: %w", err)
+		return nil, res.StatusCode, fmt.Errorf("could not read response body: %w", err)
 	}
 
-	return payload, nil
+	return payload, res.StatusCode, nil
 }

--- a/service/pipeline/addition_stage.go
+++ b/service/pipeline/addition_stage.go
@@ -3,8 +3,8 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/nsqio/go-nsq"
 	"github.com/rs/zerolog"
@@ -139,7 +139,7 @@ func (a *AdditionStage) process(payload []byte) error {
 	if err != nil {
 		return fmt.Errorf("could not decode execution error: %w", err)
 	}
-	if execErr != nil && strings.Contains(execErr.Error(), "URI query for nonexistent token") {
+	if errors.Is(execErr, results.ErrTokenNotFound) {
 		return a.delete(payload)
 	}
 	if execErr != nil {


### PR DESCRIPTION
## Goal of this PR

Fixes #228 
Fixes #230 

* Makes the metadata fetcher return the status code of its requests
* Makes the addition worker look at the `error` field within its payload when it receives an Internal Server Error or Not Found Error from the fetcher
* Makes the addition stage use the sentinel error for `ErrTokenNotFound` to look for application-level/ipfs-based deleted tokens.

## Draft

This PR remains a draft for now because it might have side effects from the fact that the lambda worker no longer fails for any status code that is different to 200. It now handles the case of 500 separately, and does not error if it's just a 500 that is not related to an app-level deletion, so should it still fail just with a different error? @awfm9 